### PR TITLE
Fix grey text on nzz.ch

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -378,6 +378,8 @@ if (matchDomain('elmercurio.com')) {
 } else if (matchDomain('nzz.ch')) {
   const paywall = document.querySelector('.dynamic-regwall');
   removeDOMElement(paywall);
+  // Remove nzzinteraction class which causes text to be grey
+  Array.from(document.querySelectorAll(".nzzinteraction.articlecomponent")).map(c => c.classList.remove("nzzinteraction"))
 } else if (matchDomain('irishtimes.com')) {
   document.addEventListener('DOMContentLoaded', () => {
     const stubArticleMsg = document.querySelector('div.stub-article-msg');


### PR DESCRIPTION
Fixes grey text after first paragraph on nzz.ch by removing the class `.nzzinteraction` from article components.

**Before**
![image](https://github.com/user-attachments/assets/1cf067b8-3e5d-4ef4-9ef1-d9e9f75c341b)

**After**
![image](https://github.com/user-attachments/assets/24808ab6-883b-4f28-904a-5d7e51e36eb2)
